### PR TITLE
Disable browser-built-in tooltip

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -277,6 +277,10 @@ struct BlackjackCard {
                 $(this).attr('data-placement', 'top');
                 $(this).attr('title', `<span style='color: gray;'>kind:</span> ${data.token.kind}<br><span style='color: gray;'>leadingTrivia:</span> ${data.token.leadingTrivia}<br><span style='color: gray;'>text:</span> ${data.text}<br><span style='color: gray;'>trailingTrivia:</span> ${data.token.trailingTrivia}`);
                 $(this).tooltip("show");
+
+                // Remove title that (for some reason) remains after showing tooltip
+                // to suppress browser's built-in tooltip.
+                $(this).removeAttr("title");
               }
 
               const Range = ace.require("ace/range").Range;


### PR DESCRIPTION
This hotfix solves duplicated tooltip caused by `title` attribute being remained (for some reason) in the DOM.

<img width="440" alt="tooltip" src="https://user-images.githubusercontent.com/138476/50732061-1543dd80-11b6-11e9-9748-0f8e6f651690.png">
